### PR TITLE
Replace `EventLoopGroup`s with `MultiThreadIoEventLoopGroup`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,16 +10,19 @@ dependencies {
     implementation(platform("org.openrewrite:rewrite-bom:$rewriteVersion"))
     implementation("org.openrewrite:rewrite-java")
 //    implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
-//    implementation("org.openrewrite:rewrite-templating:$rewriteVersion")
+    implementation("org.openrewrite:rewrite-templating:$rewriteVersion")
 
-//    annotationProcessor("org.openrewrite:rewrite-templating:$rewriteVersion")
-//    compileOnly("com.google.errorprone:error_prone_core:2.+") {
-//        exclude("com.google.auto.service", "auto-service-annotations")
-//        exclude("io.github.eisop","dataflow-errorprone")
-//    }
+    annotationProcessor("org.openrewrite:rewrite-templating:$rewriteVersion")
+    compileOnly("com.google.errorprone:error_prone_core:2.+") {
+        exclude("com.google.auto.service", "auto-service-annotations")
+        exclude("io.github.eisop","dataflow-errorprone")
+    }
+    compileOnly("io.netty:netty-all:4.2.+")
 
     testImplementation("org.openrewrite:rewrite-java-21")
     testImplementation("org.openrewrite:rewrite-test")
+
+    testRuntimeOnly("io.netty:netty-all:4.2.+")
 }
 
 recipeDependencies {

--- a/src/main/java/org/openrewrite/java/netty/EventLoopGroupToMultiThreadIoEventLoopGroup.java
+++ b/src/main/java/org/openrewrite/java/netty/EventLoopGroupToMultiThreadIoEventLoopGroup.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.netty;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollIoHandler;
+import io.netty.channel.local.LocalEventLoopGroup;
+import io.netty.channel.local.LocalIoHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import org.openrewrite.java.template.RecipeDescriptor;
+
+@RecipeDescriptor(
+        name = "Replace all `EventLoopGroup`s with `MultiThreadIoEventLoopGroup`",
+        description = "Replaces Netty's `new *EventLoopGroup` with `new MultiThreadIoEventLoopGroup(*IoHandler.newFactory())`.",
+        tags = {"netty"}
+)
+public class EventLoopGroupToMultiThreadIoEventLoopGroup {
+    @RecipeDescriptor(
+            name = "Replace `EpollEventLoopGroup` with `MultiThreadIoEventLoopGroup`",
+            description = "Replace `new EpollEventLoopGroup()` with `new MultiThreadIoEventLoopGroup(EpollIoHandler.newFactory())`.",
+            tags = {"netty", "epoll"}
+    )
+    public static class EpollEventLoopGroupFactory {
+        @BeforeTemplate
+        EventLoopGroup before() {
+            return new EpollEventLoopGroup();
+        }
+
+        @AfterTemplate
+        EventLoopGroup after() {
+            return new MultiThreadIoEventLoopGroup(EpollIoHandler.newFactory());
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `LocalEventLoopGroup` with `MultiThreadIoEventLoopGroup`",
+            description = "Replace `new LocalEventLoopGroup()` with `new MultiThreadIoEventLoopGroup(LocalIoHandler.newFactory())`.",
+            tags = {"netty", "local"}
+    )
+    public static class LocalEventLoopGroupFactory {
+        @BeforeTemplate
+        EventLoopGroup before() {
+            return new LocalEventLoopGroup();
+        }
+
+        @AfterTemplate
+        EventLoopGroup after() {
+            return new MultiThreadIoEventLoopGroup(LocalIoHandler.newFactory());
+        }
+    }
+
+    @RecipeDescriptor(
+            name = "Replace `NioEventLoopGroup` with `MultiThreadIoEventLoopGroup`",
+            description = "Replace `new NioEventLoopGroup()` with `new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory())`.",
+            tags = {"netty", "nio"}
+    )
+    public static class NioEventLoopGroupFactory {
+        @BeforeTemplate
+        EventLoopGroup before() {
+            return new NioEventLoopGroup();
+        }
+
+        @AfterTemplate
+        EventLoopGroup after() {
+            return new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+        }
+    }
+}

--- a/src/test/java/org/openrewrite/java/netty/EventLoopGroupToMultiThreadIoEventLoopGroupTest.java
+++ b/src/test/java/org/openrewrite/java/netty/EventLoopGroupToMultiThreadIoEventLoopGroupTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.netty;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class EventLoopGroupToMultiThreadIoEventLoopGroupTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new EventLoopGroupToMultiThreadIoEventLoopGroupRecipes())
+          .parser(JavaParser.fromJavaVersion().classpath(
+            "netty-transport"));
+    }
+
+    @DocumentExample
+    @Test
+    void replaceEpoll() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.netty.channel.EventLoopGroup;
+              import io.netty.channel.epoll.EpollEventLoopGroup;
+
+              class Test {
+                  EventLoopGroup group1 = new EpollEventLoopGroup();
+              }
+              """,
+            """
+              import io.netty.channel.EventLoopGroup;
+              import io.netty.channel.MultiThreadIoEventLoopGroup;
+              import io.netty.channel.epoll.EpollIoHandler;
+
+              class Test {
+                  EventLoopGroup group1 = new MultiThreadIoEventLoopGroup(EpollIoHandler.newFactory());
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceLocal() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.netty.channel.EventLoopGroup;
+              import io.netty.channel.local.LocalEventLoopGroup;
+
+              class Test {
+                  EventLoopGroup group2 = new LocalEventLoopGroup();
+              }
+              """,
+            """
+              import io.netty.channel.EventLoopGroup;
+              import io.netty.channel.MultiThreadIoEventLoopGroup;
+              import io.netty.channel.local.LocalIoHandler;
+
+              class Test {
+                  EventLoopGroup group2 = new MultiThreadIoEventLoopGroup(LocalIoHandler.newFactory());
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceNio() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import io.netty.channel.EventLoopGroup;
+              import io.netty.channel.nio.NioEventLoopGroup;
+
+              class Test {
+                  EventLoopGroup group3 = new NioEventLoopGroup();
+              }
+              """,
+            """
+              import io.netty.channel.EventLoopGroup;
+              import io.netty.channel.MultiThreadIoEventLoopGroup;
+              import io.netty.channel.nio.NioIoHandler;
+
+              class Test {
+                  EventLoopGroup group3 = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## What's your motivation?
- Add a step listed in https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide
- Fix the build because there was no Java class for Javadoc task
- Show Refaster recipe & test support