### PR TITLE
Wrap code references in backticks in recipe description

### DIFF
--- a/src/main/java/org/openrewrite/java/netty/upgrade/_3_2_to_4_1_/StringEncoderToStandardCharsets.java
+++ b/src/main/java/org/openrewrite/java/netty/upgrade/_3_2_to_4_1_/StringEncoderToStandardCharsets.java
@@ -49,7 +49,7 @@ public class StringEncoderToStandardCharsets extends Recipe {
     final String displayName = "Migrate StringEncoder(String) to StringEncoder(StandardCharsets)";
 
     @Getter
-    final String description = "Replaces new StringEncoder(charsetName) with new StringEncoder(StandardCharsets.<constant>) " +
+    final String description = "Replaces `new StringEncoder(charsetName)` with `new StringEncoder(StandardCharsets.<constant>)` " +
             "for all standard charsets (US-ASCII, ISO-8859-1, UTF-8, UTF-16BE, UTF-16LE, UTF-16).";
 
     @Override


### PR DESCRIPTION
## Summary
- Wraps `new StringEncoder(charsetName)` and `new StringEncoder(StandardCharsets.<constant>)` in backticks in the `StringEncoderToStandardCharsets` recipe description
- The bare `<constant>` was interpreted as an unclosed JSX tag when rendered in MDX, causing the rewrite-docs site build to fail

## Test plan
- [ ] Verify the recipe description renders correctly in the docs site