### PR TITLE
Reject netty snapshots

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,3 +39,11 @@ dependencies {
 tasks.withType<JavaCompile> {
     options.compilerArgs.add("-Arewrite.javaParserClasspathFrom=resources")
 }
+
+configurations.all {
+    resolutionStrategy.componentSelection.all {
+        if (candidate.group == "io.netty" && candidate.version.endsWith("-SNAPSHOT")) {
+            reject("Reject Netty SNAPSHOTs so dynamic 4.2.+ selectors only match released versions")
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?

Configuring Gradle resolution to reject netty snapshots.

## What's your motivation?

Fixing CI instability. From what I understand it might happen at a given time that some snapshots are available, some are not and this results in us trying to use versions which don't exist:
```
Cause 1: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find io.netty:netty-buffer:4.2.14.Final-SNAPSHOT.
Searched in the following locations:
```