### PR TITLE
Add Develocity plugin and build scan configuration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,34 @@
 rootProject.name = "rewrite-netty"
+
+plugins {
+    id("com.gradle.develocity") version "latest.release"
+    id("com.gradle.common-custom-user-data-gradle-plugin") version "latest.release"
+}
+
+develocity {
+    server = "https://community.develocity.cloud/"
+
+    val isCiServer = System.getenv("CI")?.equals("true") ?: false
+    val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+    val authenticated = !accessKey.isNullOrBlank()
+    buildCache {
+        remote(develocity.buildCache) {
+            isEnabled = true
+            isPush = isCiServer && authenticated
+        }
+    }
+
+    buildScan {
+        capture {
+            fileFingerprints = true
+        }
+
+        publishing {
+            onlyIf {
+                authenticated
+            }
+        }
+
+        uploadInBackground = !isCiServer
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 develocity {
     server = "https://community.develocity.cloud/"
+    projectId = "rewrite-netty"
 
     val isCiServer = System.getenv("CI")?.equals("true") ?: false
     val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 develocity {
     server = "https://community.develocity.cloud/"
-    projectId = "rewrite-netty"
+    projectId = "rewrite"
 
     val isCiServer = System.getenv("CI")?.equals("true") ?: false
     val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 develocity {
     server = "https://community.develocity.cloud/"
-    projectId = "rewrite"
+    projectId = "openrewrite"
 
     val isCiServer = System.getenv("CI")?.equals("true") ?: false
     val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")


### PR DESCRIPTION
Aligns this module with other OpenRewrite recipe modules (e.g. rewrite-spring, rewrite-migrate-java), which apply Develocity in `settings.gradle.kts` while this one did not. Adds the `com.gradle.develocity` and `com.gradle.common-custom-user-data-gradle-plugin` plugins, pointing at `community.develocity.cloud` for build scans and a remote build cache. Cache pushes and scan publishing are gated on CI plus a non-blank `GRADLE_ENTERPRISE_ACCESS_KEY`, so the build degrades gracefully to local-only when the secret is absent.